### PR TITLE
refactor(recipe): 重构副产品相关逻辑

### DIFF
--- a/src/main/java/cn/qihuang02/fantasytools/compat/emi/FTEmiRecipe.java
+++ b/src/main/java/cn/qihuang02/fantasytools/compat/emi/FTEmiRecipe.java
@@ -52,10 +52,12 @@ public class FTEmiRecipe implements EmiRecipe {
             this.output = EmiStack.of(recipe.getResultItem(registries));
         }
 
-        this.byproductsForDisplay = recipe.byproducts().stream()
-                .map(def -> EmiStack.of(def.byproduct()))
-                .filter(stack -> !stack.isEmpty())
-                .toList();
+        this.byproductsForDisplay = recipe.byproducts()
+                .map(byproducts -> byproducts.stream()
+                        .map(def -> EmiStack.of(def.byproduct()))
+                        .filter(stack -> !stack.isEmpty())
+                        .toList())
+                .orElse(List.of());
     }
 
     @Override
@@ -195,18 +197,19 @@ public class FTEmiRecipe implements EmiRecipe {
     }
 
     private List<Component> getChanceTooltip(int index) {
-        if (index < recipe.byproducts().size()) {
-            float chance = recipe.byproducts().get(index).chance();
-            int minCount = recipe.byproducts().get(index).minCount();
-            int maxCount = recipe.byproducts().get(index).maxCount();
-            return List.of(
-                    Component.translatable("tooltip.fantasytools.portal_transform.byproduct").withStyle(ChatFormatting.GRAY),
-                    Component.translatable("tooltip.fantasytools.portal_transform.byproduct.chance", chance * 100).withStyle(ChatFormatting.GRAY),
-                    Component.translatable("tooltip.fantasytools.portal_transform.byproduct.min_count", minCount).withStyle(ChatFormatting.DARK_GRAY),
-                    Component.translatable("tooltip.fantasytools.portal_transform.byproduct.max_count", maxCount).withStyle(ChatFormatting.DARK_GRAY)
-            );
-        }
-
-        return List.of();
+        return recipe.byproducts()
+                .filter(byproducts -> index < byproducts.size())
+                .map(byproducts -> {
+                    float chance = byproducts.get(index).chance();
+                    int minCount = byproducts.get(index).minCount();
+                    int maxCount = byproducts.get(index).maxCount();
+                    return List.<Component>of(
+                            Component.translatable("tooltip.fantasytools.portal_transform.byproduct").withStyle(ChatFormatting.GRAY),
+                            Component.translatable("tooltip.fantasytools.portal_transform.byproduct.chance", chance * 100).withStyle(ChatFormatting.GRAY),
+                            Component.translatable("tooltip.fantasytools.portal_transform.byproduct.min_count", minCount).withStyle(ChatFormatting.DARK_GRAY),
+                            Component.translatable("tooltip.fantasytools.portal_transform.byproduct.max_count", maxCount).withStyle(ChatFormatting.DARK_GRAY)
+                    );
+                })
+                .orElse(List.of());
     }
 }

--- a/src/main/java/cn/qihuang02/fantasytools/compat/kubejs/components/ByproductComponent.java
+++ b/src/main/java/cn/qihuang02/fantasytools/compat/kubejs/components/ByproductComponent.java
@@ -6,8 +6,9 @@ import dev.latvian.mods.kubejs.recipe.component.RecipeComponent;
 import dev.latvian.mods.rhino.type.TypeInfo;
 
 import java.util.List;
+import java.util.Optional;
 
-public class ByproductComponent implements RecipeComponent<List<PortalTransformRecipe.ByproductDefinition>> {
+public class ByproductComponent implements RecipeComponent<Optional<List<PortalTransformRecipe.ByproductDefinition>>> {
     public static final ByproductComponent BYPRODUCT = new ByproductComponent();
 
     private ByproductComponent() {
@@ -15,13 +16,13 @@ public class ByproductComponent implements RecipeComponent<List<PortalTransformR
     }
 
     @Override
-    public Codec<List<PortalTransformRecipe.ByproductDefinition>> codec() {
+    public Codec<Optional<List<PortalTransformRecipe.ByproductDefinition>>> codec() {
         return null;
     }
 
     @Override
     public TypeInfo typeInfo() {
-        return TypeInfo.of(List.class);
+        return TypeInfo.of(Optional.class);
     }
 
     @Override

--- a/src/main/java/cn/qihuang02/fantasytools/event/PortalTransformHandler.java
+++ b/src/main/java/cn/qihuang02/fantasytools/event/PortalTransformHandler.java
@@ -111,9 +111,8 @@ public class PortalTransformHandler {
 
         itemEntity.setItem(outputStack);
 
-        if (!recipe.getByproducts().isEmpty()) {
-
-            for (PortalTransformRecipe.ByproductDefinition definition : recipe.getByproducts()) {
+        recipe.getByproducts().ifPresent(byproducts -> {
+            for (PortalTransformRecipe.ByproductDefinition definition : byproducts) {
                 int byproductSpawnedTotalThisType = 0;
 
                 if (
@@ -153,6 +152,6 @@ public class PortalTransformHandler {
                     }
                 }
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
- 将副产品列表由 List 改为 Optional<List>，以更准确地表示可能为空的情况
- 优化副产品相关代码的结构，提高可读性和健壮性 -调整副产品的序列化和反序列化方式，提高数据处理的灵活性